### PR TITLE
PRをcloseするCIにcheckoutのstep追加

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -15,6 +15,7 @@ jobs:
   close-pr:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3.0.2
       - uses: ./
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
https://github.com/dev-hato/actions-close-pr/runs/7359261337?check_suite_focus=true

```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/actions-close-pr/actions-close-pr'. Did you forget to run actions/checkout before running your local action?
```

checkoutしないと `action.yml` を参照できないので、checkoutのstepを追加します。