### PR TITLE
PRをcloseするCIにnpm ciのstep追加

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
+      - uses: actions/setup-node@v3.3.0
+        with:
+          cache: npm
+      - run: npm ci --prefer-offline
       - uses: ./
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
https://github.com/dev-hato/actions-close-pr/runs/7359536811?check_suite_focus=true

```
Error: Unhandled error: Error: Cannot find module 'js-yaml'
```

`js-yaml` をインストールする必要があるので、 `npm ci` のstepを追加します。